### PR TITLE
feature 014_1: Se agregan skeleton, error, y persistencia de datos al paso 1

### DIFF
--- a/lib/features/booking/presentation/booking_first_step_screen.dart
+++ b/lib/features/booking/presentation/booking_first_step_screen.dart
@@ -3,10 +3,13 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:kara/features/common/theme/app_colors.dart';
 
 import '../../../core/config/l10n/generated/app_localizations.dart';
+import '../../../core/networking/api_response.dart';
 import 'view_model/booking_view_model.dart';
+import 'widgets/category_error.dart';
 import 'widgets/category_list.dart';
+import 'widgets/category_skeleton.dart';
 
-class BookingFirstStepScreen extends ConsumerStatefulWidget {
+class BookingFirstStepScreen extends ConsumerWidget {
   final AppLocalizations? localizations;
   final ThemeData appTheme;
   final PageController pageController;
@@ -19,127 +22,108 @@ class BookingFirstStepScreen extends ConsumerStatefulWidget {
   });
 
   @override
-  ConsumerState<BookingFirstStepScreen> createState() =>
-      _BookingFirstStepScreenState();
-}
+  Widget build(BuildContext context, WidgetRef ref) {
+    final AsyncValue<BookingState> getCategoriesProvider = ref.watch(
+      bookingViewModelProvider,
+    );
 
-class _BookingFirstStepScreenState
-    extends ConsumerState<BookingFirstStepScreen> {
-  bool isEnableNextButton = false;
+    bool isEnableNextButton =
+        getCategoriesProvider.hasError
+            ? false
+            : getCategoriesProvider.value != null
+            ? getCategoriesProvider.value!.categoriesSelected.isNotEmpty
+            : false;
 
-  @override
-  Widget build(BuildContext context) {
-    return FutureBuilder(
-      future: ref.watch(getCategoriesProvider.future),
-      builder: (context, snapshot) {
-        if (snapshot.connectionState == ConnectionState.waiting) {
-          return const Center(
-            child: CircularProgressIndicator(color: AppColors.blue),
-          );
-        } else if (snapshot.hasError) {
-          return Center(
-            child: Text(
-              '${widget.localizations!.label_unknow_error}: ${snapshot.error}',
-            ),
-          );
-        } else if (snapshot.hasData) {
-          final categories = snapshot.data!;
-          if (categories.isEmpty) {
-            return Center(
-              child: Text(widget.localizations!.title_something_went_wrong),
-            );
-          } else {
-            return Container(
-              color: widget.appTheme.colorScheme.primary,
-              child: Column(
-                children: [
-                  Padding(
-                    padding: const EdgeInsets.only(top: 20.0),
-                    child: Center(
-                      child: Text(
-                        widget.localizations!.label_select_service,
-                        style: TextStyle(
-                          color: widget.appTheme.colorScheme.secondary,
-                          fontSize: 18,
-                        ),
+    return getCategoriesProvider.when(
+      data:
+          (BookingState bookingState) => Container(
+            color: appTheme.colorScheme.primary,
+            child: Column(
+              children: [
+                Padding(
+                  padding: const EdgeInsets.only(top: 20.0),
+                  child: Center(
+                    child: Text(
+                      localizations!.label_select_service,
+                      style: TextStyle(
+                        color: appTheme.colorScheme.secondary,
+                        fontSize: 18,
                       ),
                     ),
                   ),
-                  Padding(
-                    padding: const EdgeInsets.only(top: 2.0),
-                    child: Center(
+                ),
+                Padding(
+                  padding: const EdgeInsets.only(top: 2.0),
+                  child: Center(
+                    child: Text(
+                      localizations!.label_multiple_services,
+                      style: const TextStyle(
+                        color: AppColors.greyDark,
+                        fontSize: 13,
+                      ),
+                    ),
+                  ),
+                ),
+                CategoryList(localizations: localizations!),
+                Container(
+                  decoration: const BoxDecoration(
+                    borderRadius: BorderRadius.only(
+                      topLeft: Radius.circular(20),
+                      topRight: Radius.circular(20),
+                    ),
+                  ),
+                  child: Padding(
+                    padding: const EdgeInsets.symmetric(vertical: 16.0),
+                    child: ElevatedButton(
+                      style: ElevatedButton.styleFrom(
+                        backgroundColor:
+                            isEnableNextButton
+                                ? appTheme.colorScheme.secondary
+                                : AppColors.greyLight,
+                        foregroundColor:
+                            isEnableNextButton
+                                ? appTheme.colorScheme.primary
+                                : AppColors.black,
+                        minimumSize: const Size(343, 43),
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(10.0),
+                        ),
+                      ),
+                      onPressed:
+                          () =>
+                              isEnableNextButton
+                                  ? pageController.nextPage(
+                                    duration: const Duration(
+                                      milliseconds: 1000,
+                                    ),
+                                    curve: Curves.easeInOut,
+                                  )
+                                  : null,
                       child: Text(
-                        widget.localizations!.label_multiple_services,
+                        localizations!.label_next,
                         style: const TextStyle(
-                          color: AppColors.greyDark,
-                          fontSize: 13,
+                          fontSize: 16,
+                          fontWeight: FontWeight.w600,
                         ),
                       ),
                     ),
                   ),
-                  CategoryList(
-                    categories: categories,
-                    onCategorySelected: (selectedList) {
-                      setState(() {
-                        isEnableNextButton = selectedList.isNotEmpty;
-                      });
-                    },
-                    localizations: widget.localizations!,
-                  ),
-                  Container(
-                    decoration: const BoxDecoration(
-                      borderRadius: BorderRadius.only(
-                        topLeft: Radius.circular(20),
-                        topRight: Radius.circular(20),
-                      ),
-                    ),
-                    child: Padding(
-                      padding: const EdgeInsets.symmetric(vertical: 16.0),
-                      child: ElevatedButton(
-                        style: ElevatedButton.styleFrom(
-                          backgroundColor:
-                              isEnableNextButton
-                                  ? widget.appTheme.colorScheme.secondary
-                                  : AppColors.greyLight,
-                          foregroundColor:
-                              isEnableNextButton
-                                  ? widget.appTheme.colorScheme.primary
-                                  : AppColors.black,
-                          minimumSize: const Size(343, 43),
-                          shape: RoundedRectangleBorder(
-                            borderRadius: BorderRadius.circular(10.0),
-                          ),
-                        ),
-                        onPressed:
-                            () =>
-                                isEnableNextButton
-                                    ? widget.pageController.nextPage(
-                                      duration: const Duration(
-                                        milliseconds: 1000,
-                                      ),
-                                      curve: Curves.easeInOut,
-                                    )
-                                    : null,
-                        child: Text(
-                          widget.localizations!.label_next,
-                          style: const TextStyle(
-                            fontSize: 16,
-                            fontWeight: FontWeight.w600,
-                          ),
-                        ),
-                      ),
-                    ),
-                  ),
-                ],
-              ),
-            );
-          }
-        } else {
-          return Center(
-            child: Text(widget.localizations!.title_something_went_wrong),
-          );
-        }
-      },
+                ),
+              ],
+            ),
+          ),
+      error:
+          (error, stackTrace) => CategoryError(
+            localizations: localizations!,
+            errorResponse: error as ErrorApiResponse,
+            isLoading: getCategoriesProvider.isLoading,
+            onRetry:
+                () =>
+                    ref
+                        .read(bookingViewModelProvider.notifier)
+                        .fetchCategories(),
+          ),
+      loading: () => const CategorySkeleton(),
     );
   }
 }

--- a/lib/features/booking/presentation/view_model/booking_view_model.dart
+++ b/lib/features/booking/presentation/view_model/booking_view_model.dart
@@ -1,13 +1,59 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import '../../data/repositories/booking_repository_impl.dart';
 import '../../domain/entities/service_category_entity.dart';
 
+part 'booking_view_model.freezed.dart';
 part 'booking_view_model.g.dart';
 
-@riverpod
-Future<List<ServiceCategoryEntity>> getCategories(ref) async {
-  final bookingRepository = ref.watch(bookingRepositoryProvider);
+@freezed
+class BookingState with _$BookingState {
+  const factory BookingState({
+    @Default([]) List<ServiceCategoryEntity> categories,
+    @Default([]) List<ServiceCategoryEntity> categoriesSelected,
+  }) = _BookingState;
+}
 
-  return await bookingRepository.getCategories();
+@Riverpod(keepAlive: true)
+class BookingViewModel extends _$BookingViewModel {
+  @override
+  FutureOr<BookingState> build() => const BookingState();
+
+  Future<void> fetchCategories() async {
+    state = const AsyncValue.loading();
+    final bookingRepository = ref.read(bookingRepositoryProvider);
+
+    try {
+      final categories = await bookingRepository.getCategories();
+      state = AsyncValue.data(
+        BookingState(categories: categories, categoriesSelected: []),
+      );
+    } catch (error, stackTrace) {
+      state = AsyncValue.error(error, stackTrace);
+      rethrow;
+    }
+  }
+
+  void addCategory(ServiceCategoryEntity category) {
+    final currentState = state.value!;
+    final updatedSelectedCategories = List<ServiceCategoryEntity>.from(
+      currentState.categoriesSelected,
+    )..add(category);
+
+    state = AsyncValue.data(
+      currentState.copyWith(categoriesSelected: updatedSelectedCategories),
+    );
+  }
+
+  void removeCategory(ServiceCategoryEntity category) {
+    final currentState = state.value!;
+    final updatedSelectedCategories = List<ServiceCategoryEntity>.from(
+      currentState.categoriesSelected,
+    )..remove(category);
+
+    state = AsyncValue.data(
+      currentState.copyWith(categoriesSelected: updatedSelectedCategories),
+    );
+  }
 }

--- a/lib/features/booking/presentation/view_model/booking_view_model.freezed.dart
+++ b/lib/features/booking/presentation/view_model/booking_view_model.freezed.dart
@@ -1,0 +1,191 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'booking_view_model.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+/// @nodoc
+mixin _$BookingState {
+  List<ServiceCategoryEntity> get categories =>
+      throw _privateConstructorUsedError;
+  List<ServiceCategoryEntity> get categoriesSelected =>
+      throw _privateConstructorUsedError;
+
+  /// Create a copy of BookingState
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $BookingStateCopyWith<BookingState> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $BookingStateCopyWith<$Res> {
+  factory $BookingStateCopyWith(
+          BookingState value, $Res Function(BookingState) then) =
+      _$BookingStateCopyWithImpl<$Res, BookingState>;
+  @useResult
+  $Res call(
+      {List<ServiceCategoryEntity> categories,
+      List<ServiceCategoryEntity> categoriesSelected});
+}
+
+/// @nodoc
+class _$BookingStateCopyWithImpl<$Res, $Val extends BookingState>
+    implements $BookingStateCopyWith<$Res> {
+  _$BookingStateCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of BookingState
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? categories = null,
+    Object? categoriesSelected = null,
+  }) {
+    return _then(_value.copyWith(
+      categories: null == categories
+          ? _value.categories
+          : categories // ignore: cast_nullable_to_non_nullable
+              as List<ServiceCategoryEntity>,
+      categoriesSelected: null == categoriesSelected
+          ? _value.categoriesSelected
+          : categoriesSelected // ignore: cast_nullable_to_non_nullable
+              as List<ServiceCategoryEntity>,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$BookingStateImplCopyWith<$Res>
+    implements $BookingStateCopyWith<$Res> {
+  factory _$$BookingStateImplCopyWith(
+          _$BookingStateImpl value, $Res Function(_$BookingStateImpl) then) =
+      __$$BookingStateImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {List<ServiceCategoryEntity> categories,
+      List<ServiceCategoryEntity> categoriesSelected});
+}
+
+/// @nodoc
+class __$$BookingStateImplCopyWithImpl<$Res>
+    extends _$BookingStateCopyWithImpl<$Res, _$BookingStateImpl>
+    implements _$$BookingStateImplCopyWith<$Res> {
+  __$$BookingStateImplCopyWithImpl(
+      _$BookingStateImpl _value, $Res Function(_$BookingStateImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of BookingState
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? categories = null,
+    Object? categoriesSelected = null,
+  }) {
+    return _then(_$BookingStateImpl(
+      categories: null == categories
+          ? _value._categories
+          : categories // ignore: cast_nullable_to_non_nullable
+              as List<ServiceCategoryEntity>,
+      categoriesSelected: null == categoriesSelected
+          ? _value._categoriesSelected
+          : categoriesSelected // ignore: cast_nullable_to_non_nullable
+              as List<ServiceCategoryEntity>,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$BookingStateImpl implements _BookingState {
+  const _$BookingStateImpl(
+      {final List<ServiceCategoryEntity> categories = const [],
+      final List<ServiceCategoryEntity> categoriesSelected = const []})
+      : _categories = categories,
+        _categoriesSelected = categoriesSelected;
+
+  final List<ServiceCategoryEntity> _categories;
+  @override
+  @JsonKey()
+  List<ServiceCategoryEntity> get categories {
+    if (_categories is EqualUnmodifiableListView) return _categories;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_categories);
+  }
+
+  final List<ServiceCategoryEntity> _categoriesSelected;
+  @override
+  @JsonKey()
+  List<ServiceCategoryEntity> get categoriesSelected {
+    if (_categoriesSelected is EqualUnmodifiableListView)
+      return _categoriesSelected;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_categoriesSelected);
+  }
+
+  @override
+  String toString() {
+    return 'BookingState(categories: $categories, categoriesSelected: $categoriesSelected)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$BookingStateImpl &&
+            const DeepCollectionEquality()
+                .equals(other._categories, _categories) &&
+            const DeepCollectionEquality()
+                .equals(other._categoriesSelected, _categoriesSelected));
+  }
+
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      const DeepCollectionEquality().hash(_categories),
+      const DeepCollectionEquality().hash(_categoriesSelected));
+
+  /// Create a copy of BookingState
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$BookingStateImplCopyWith<_$BookingStateImpl> get copyWith =>
+      __$$BookingStateImplCopyWithImpl<_$BookingStateImpl>(this, _$identity);
+}
+
+abstract class _BookingState implements BookingState {
+  const factory _BookingState(
+          {final List<ServiceCategoryEntity> categories,
+          final List<ServiceCategoryEntity> categoriesSelected}) =
+      _$BookingStateImpl;
+
+  @override
+  List<ServiceCategoryEntity> get categories;
+  @override
+  List<ServiceCategoryEntity> get categoriesSelected;
+
+  /// Create a copy of BookingState
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$BookingStateImplCopyWith<_$BookingStateImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/features/booking/presentation/view_model/booking_view_model.g.dart
+++ b/lib/features/booking/presentation/view_model/booking_view_model.g.dart
@@ -6,24 +6,21 @@ part of 'booking_view_model.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$getCategoriesHash() => r'63355b61fcf6536af3bad51180616a2e2d9050d6';
+String _$bookingViewModelHash() => r'd3d031e6e7223d6433b19be78e497bb853f8e499';
 
-/// See also [getCategories].
-@ProviderFor(getCategories)
-final getCategoriesProvider =
-    AutoDisposeFutureProvider<List<ServiceCategoryEntity>>.internal(
-  getCategories,
-  name: r'getCategoriesProvider',
+/// See also [BookingViewModel].
+@ProviderFor(BookingViewModel)
+final bookingViewModelProvider =
+    AsyncNotifierProvider<BookingViewModel, BookingState>.internal(
+  BookingViewModel.new,
+  name: r'bookingViewModelProvider',
   debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
       ? null
-      : _$getCategoriesHash,
+      : _$bookingViewModelHash,
   dependencies: null,
   allTransitiveDependencies: null,
 );
 
-@Deprecated('Will be removed in 3.0. Use Ref instead')
-// ignore: unused_element
-typedef GetCategoriesRef
-    = AutoDisposeFutureProviderRef<List<ServiceCategoryEntity>>;
+typedef _$BookingViewModel = AsyncNotifier<BookingState>;
 // ignore_for_file: type=lint
 // ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/lib/features/booking/presentation/widgets/booking_base.dart
+++ b/lib/features/booking/presentation/widgets/booking_base.dart
@@ -1,11 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import 'package:kara/features/booking/presentation/view_model/booking_view_model.dart';
 import 'package:kara/features/common/ui/contruction_message_screen.dart';
 
 import '../../../../core/config/l10n/generated/app_localizations.dart';
 import '../booking_first_step_screen.dart';
-import '../view_model/booking_view_model.dart';
 import 'step_progress.dart';
 
 class BookingBase extends ConsumerStatefulWidget {
@@ -50,7 +50,7 @@ class _AppointmentBookingScreenState extends ConsumerState<BookingBase> {
           onPressed: () {
             if (_currentStep == 0) {
               context.pop();
-              ref.invalidate(getCategoriesProvider);
+              ref.invalidate(bookingViewModelProvider);
             } else {
               _pageController.previousPage(
                 duration: const Duration(milliseconds: 1000),

--- a/lib/features/booking/presentation/widgets/category_error.dart
+++ b/lib/features/booking/presentation/widgets/category_error.dart
@@ -1,0 +1,62 @@
+import 'package:flutter/material.dart';
+
+import '../../../../core/config/l10n/generated/app_localizations.dart';
+import '../../../../core/networking/api_response.dart';
+import '../../../common/assets.dart';
+import '../../../common/ui/ghost_button.dart';
+
+class CategoryError extends StatelessWidget {
+  final AppLocalizations localizations;
+  final ErrorApiResponse errorResponse;
+  final bool isLoading;
+  final Function() onRetry;
+  const CategoryError({
+    super.key,
+    required this.localizations,
+    required this.errorResponse,
+    required this.onRetry,
+    required this.isLoading,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 32.0),
+      child: Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Image.asset(AppAssets.whatIcon, width: 200, height: 200),
+            const SizedBox(height: 16),
+            Text(
+              localizations.title_something_went_wrong,
+              textAlign: TextAlign.center,
+              style: const TextStyle(
+                fontSize: 20,
+                fontWeight: FontWeight.bold,
+                color: Colors.black87,
+              ),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              localizations.label_status_error(
+                errorResponse.errors?.join(', ') ??
+                    localizations.label_unknow_error,
+                errorResponse.httpStatusCode,
+              ),
+              textAlign: TextAlign.center,
+              style: TextStyle(fontSize: 14, color: Colors.grey[600]),
+            ),
+            const SizedBox(height: 16),
+            GhostButton.secondary(
+              label: localizations.label_retry,
+              icon: const Icon(Icons.refresh),
+              onPressed: onRetry,
+              isLoading: isLoading,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/booking/presentation/widgets/category_skeleton.dart
+++ b/lib/features/booking/presentation/widgets/category_skeleton.dart
@@ -1,0 +1,99 @@
+import 'package:flutter/material.dart';
+import 'package:shimmer/shimmer.dart';
+
+import '../../../common/theme/app_colors.dart';
+import '../../../common/ui/shimmer_box.dart';
+
+class CategorySkeleton extends StatelessWidget {
+  const CategorySkeleton({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        const Padding(
+          padding: EdgeInsets.only(top: 20.0),
+          child: Center(child: ShimmerBox(width: 240, height: 15)),
+        ),
+        const Padding(
+          padding: EdgeInsets.only(top: 10.0),
+          child: Center(child: ShimmerBox(width: 190, height: 12)),
+        ),
+        Expanded(
+          child: ListView.separated(
+            padding: const EdgeInsets.only(top: 26),
+            itemCount: 5,
+            separatorBuilder: (context, index) => const SizedBox(height: 4),
+            itemBuilder: (context, index) {
+              return Card(
+                elevation: 0,
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(20.0),
+                ),
+                color: const Color.fromARGB(248, 248, 248, 248),
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(vertical: 12.0),
+                  child: Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceAround,
+                    children: [
+                      Shimmer.fromColors(
+                        baseColor: Colors.grey[300]!,
+                        highlightColor: Colors.grey[100]!,
+                        child: const CircleAvatar(
+                          maxRadius: 26,
+                          backgroundColor: Color.fromARGB(255, 237, 237, 237),
+                        ),
+                      ),
+                      const Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          ShimmerBox(width: 110, height: 14),
+                          SizedBox(height: 8),
+                          ShimmerBox(width: 150, height: 12),
+                          SizedBox(height: 8),
+                          ShimmerBox(width: 100, height: 12),
+                        ],
+                      ),
+                      Opacity(
+                        opacity: 0.0,
+                        child: Transform.scale(
+                          scale: 1.2,
+                          child: Checkbox(
+                            value: true,
+                            onChanged: (bool? value) {},
+                            shape: RoundedRectangleBorder(
+                              borderRadius: BorderRadius.circular(10.0),
+                            ),
+                            activeColor: const Color.fromARGB(
+                              248,
+                              248,
+                              248,
+                              248,
+                            ),
+                            checkColor: AppColors.blue,
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              );
+            },
+          ),
+        ),
+        Container(
+          decoration: const BoxDecoration(
+            borderRadius: BorderRadius.only(
+              topLeft: Radius.circular(20),
+              topRight: Radius.circular(20),
+            ),
+          ),
+          child: const Padding(
+            padding: EdgeInsets.symmetric(vertical: 16.0),
+            child: ShimmerBox(width: 343, height: 43),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/home/presentation/home_screen.dart
+++ b/lib/features/home/presentation/home_screen.dart
@@ -6,6 +6,7 @@ import 'package:kara/features/home/presentation/widgets/appointments_list.dart';
 import '../../../core/navigation/app_navigation.dart';
 import '../../../core/networking/api_response.dart';
 import '../../auth/presentation/view_model/auth_view_model.dart';
+import '../../booking/presentation/view_model/booking_view_model.dart';
 import '../../common/mixins/auth_mixin.dart';
 import '../../common/ui/appointments_header.dart';
 import '../../common/ui/default_app_bar.dart';
@@ -63,7 +64,10 @@ class HomeScreen extends ConsumerWidget with BaseModel, AuthMixin {
             subtitle: localizations!.label_appointments_count(
               totalAppointments,
             ),
-            onAddAppointment: () => context.push(AppNavigation.booking),
+            onAddAppointment: () {
+              context.push(AppNavigation.booking);
+              ref.read(bookingViewModelProvider.notifier).fetchCategories();
+            },
           ),
           const Padding(
             padding: EdgeInsets.symmetric(horizontal: 32.0),


### PR DESCRIPTION
# 🚀 Pull Request

------ --- ---

## 📄 Se agregan al paso 1:

1. Skeleton de carga del servicio de categorias.
2. Pantalla de error del servicio de categorias.
3. Persistencia de datos; permanecen las categorias, y las categorias seleccionadas entre los pasos.
4. **Se atiende comentario del BookingViewModel (pasarlo a clase).**

------ --- ---

### 🔗 Tareas relacionadas
<!-- Si aplica, enlazá el ticket/issue -->

1. Feature 014_1: Paso 1 Skeleton, errorres, y otros.

------ --- ---

### 🧪 Cómo probar

<!-- Instrucciones para probar este PR de forma local -->
#### Creacion de cuenta
1. `flutter pub get`
5. Iniciar el app.
6. Iniciar sesión => Visualiza home.
7. Tap en "+".
8. Seleccionar las categorias de servicios que desea.

------ --- ---

## ✅ Checklist
- [X] El código compila y corre sin errores
- [X] Pasaron los tests si aplica
- [X] Se agregaron o actualizaron traducciones (`.arb`) si aplica
- [X] Se siguió el estilo del proyecto (formato, nombres, etc.)
- [X] Este PR está listo para revisión

------ --- ---

## 📸 Evidencia 
### Persistencia
https://github.com/user-attachments/assets/f3d85912-f56c-4a47-98b5-eccaae4242f0

### Skeleton
<img width="263" height="785" alt="skeleton" src="https://github.com/user-attachments/assets/a0d03e1e-e10d-466d-bf1b-f24348901568" />


### Error y reintentos
<img width="269" height="798" alt="Error y reintentos" src="https://github.com/user-attachments/assets/37acf3a6-b64e-4639-844e-932592fe4512" />


------ --- ---


🧙🏼 Revisores: @gomezmedinamoises @RicDev116